### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is the **CoolStore** cloud-native workshop application — a polyglot microservices e-commerce demo. It consists of 4 required services that together form the full product catalog experience.
+
+### Services
+
+| Service | Tech | Directory | Default Port | Run Command |
+|---|---|---|---|---|
+| Inventory | Quarkus 1.7.2 (Java) | `labs/inventory-quarkus` | 8080 | `mvn compile quarkus:dev -Ddebug=false` |
+| Catalog | Spring Boot 2.1.6 (Java) | `labs/catalog-spring-boot` | 9000 | `mvn spring-boot:run` |
+| Gateway | Vert.x 3.6.3 (Java) | `labs/gateway-vertx` | 8090 (see note) | Build jar then `java -Dhttp.port=8090 -jar target/gateway-1.0-SNAPSHOT.jar` |
+| Web UI | Node.js / AngularJS | `labs/web-nodejs` | 3000 | `COOLSTORE_GW_ENDPOINT=http://localhost:8090 PORT=3000 node .` |
+
+### Prerequisites
+
+- **JDK 11** — required for all Java services. Set `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64` before running Maven commands. JDK 21 (default) is too new for the Red Hat BOM dependencies.
+- **Maven 3.x** — installed via apt (`openjdk-11-jdk` and `maven` packages).
+- **Node.js** — any recent LTS version works for the Web UI. Install deps with `npm install --ignore-scripts` (the `postinstall` hook for `license-reporter` can be skipped).
+
+### Port configuration gotchas
+
+- The Gateway Vert.x service ignores `-Dhttp.port` when run via `mvn vertx:run` because the plugin forks a new JVM. You must first `mvn clean package -DskipTests` then run the fat jar directly: `java -Dhttp.port=8090 -jar target/gateway-1.0-SNAPSHOT.jar`.
+- The Gateway defaults to connecting to Catalog and Inventory on `localhost:9001`. Override via env vars: `COMPONENT_CATALOG_HOST`, `COMPONENT_CATALOG_PORT`, `COMPONENT_INVENTORY_HOST`, `COMPONENT_INVENTORY_PORT`.
+- The Catalog Spring Boot service runs on port 9000 (configured in `pom.xml` jvmArguments: `-Dserver.port=9000`).
+- The Web UI reads `COOLSTORE_GW_ENDPOINT` env var to know where the Gateway API lives.
+
+### Databases
+
+All services use **in-memory H2** by default — no external database setup is needed. Data is seeded from `import.sql` files in each service's resources.
+
+### Testing
+
+- `mvn test` in `labs/inventory-quarkus` — the included test (`InventoryResourceTest`) tests a scaffold `/hello` endpoint that doesn't exist in the working implementation. This failure is expected and part of the workshop design.
+- `labs/catalog-spring-boot` and `labs/gateway-vertx` have no unit tests.
+- `npx xo` in `labs/web-nodejs` runs the linter (255 pre-existing style errors in the workshop code).
+- The `labs/catalog-go` directory contains an alternative Go-based catalog service for service mesh A/B testing labs (optional).
+
+### Build commands
+
+All Java services: `mvn clean package -DskipTests` from their respective directories (with `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment setup instructions for Cursor Cloud agents.

### What's included

- Service overview table (Inventory/Catalog/Gateway/Web UI) with ports and run commands
- JDK 11 and Maven prerequisites documentation
- Port configuration gotchas (Gateway Vert.x fat-jar workaround, env var overrides)
- Database notes (all services use in-memory H2 by default)
- Testing notes (scaffold test limitations, linter pre-existing errors)
- Build commands reference

### Services verified end-to-end

| Service | Tech | Port | Status |
|---|---|---|---|
| Inventory | Quarkus 1.7.2 | 8080 | Working |
| Catalog | Spring Boot 2.1.6 | 9000 | Working |
| Gateway | Vert.x 3.6.3 | 8090 | Working |
| Web UI | Node.js/AngularJS | 3000 | Working |

### Demo

[coolstore_e2e_demo.mp4](https://cursor.com/agents/bc-95164af4-0a04-42c2-96e5-a9a998d57930/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcoolstore_e2e_demo.mp4)

CoolStore product catalog with all 9 products displayed, showing prices and live inventory quantities from the full microservices stack.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95164af4-0a04-42c2-96e5-a9a998d57930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95164af4-0a04-42c2-96e5-a9a998d57930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

